### PR TITLE
F/1774 add sandbox capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG.md
 
+## Unreleased
+
+Added
+- Custom configurations can be passed as a JSON string through the `dcatConfig` query param [#6](https://github.com/koopjs/koop-output-dcat-us-11/pull/6)
+- The returned feed can be restricted to a single dataset with the `id` query param [#6](https://github.com/koopjs/koop-output-dcat-us-11/pull/6)
+
 ## 1.1.0
 Added
 - Supports custom configuration values found at `site.data.feeds.dcatUS11` [#4](https://github.com/koopjs/koop-output-dcat-us-11/pull/4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 Added
-- Custom configurations can be passed as a JSON string through the `dcatConfig` query param [#6](https://github.com/koopjs/koop-output-dcat-us-11/pull/6)
+- Custom configurations can be passed through the `dcatConfig` query param [#6](https://github.com/koopjs/koop-output-dcat-us-11/pull/6)
 - The returned feed can be restricted to a single dataset with the `id` query param [#6](https://github.com/koopjs/koop-output-dcat-us-11/pull/6)
 
 ## 1.1.0


### PR DESCRIPTION
Part of https://devtopia.esri.com/dc/hub/issues/1774

Adds `dcatConfig` and `id` query params.
- `?dcatConfig="{\"customProperty\":\"custom value\"}"`
- `?id= 1c36f0f21ba34a7aa1f5d48f7313cf6b_0`

`dcatConfig` is ignored if it is malformed JSON.
if `id` is invalid or refers to a private item, the feed will return empty.