### PR TITLE
b/2527 fix parsing of dcatConfig query param

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -168,7 +168,7 @@ describe('Output Plugin', () => {
         });
     })
 
-    it('Properly passes custom dcat configurations to getDataStreamDcatUs11', async () => {
+    it('Properly passes a site\'s custom dcat configurations to getDataStreamDcatUs11 when no dcatConfig is provided', async () => {
       // Change fetchSite's return value to include a custom dcat config
       const customConfigSiteModel: IModel = _.cloneDeep(mockSiteModel);
       customConfigSiteModel.data.feeds = {
@@ -198,13 +198,29 @@ describe('Output Plugin', () => {
         });
     });
 
-    it('Properly passes the ?dcatConfig query param to getDataStreamDcatUs11', async () => {
+    it('Properly passes a valid stringified ?dcatConfig query param to getDataStreamDcatUs11', async () => {
       const dcatConfig = {
         planet: 'tatooine'
       }
 
       await request(app)
         .get(`/dcat?dcatConfig=${JSON.stringify(dcatConfig)}`)
+        .set('host', siteHostName)
+        .expect('Content-Type', /application\/json/)
+        .expect(200)
+        .expect(() => {
+          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(mockSiteModel.item, dcatConfig);
+        });
+    });
+
+    it('Properly passes the ?dcatConfig query param as an object to getDataStreamDcatUs11', async () => {
+      const dcatConfig = {
+        planet: 'tatooine'
+      }
+
+      await request(app)
+        .get('/dcat')
+        .query({ dcatConfig })
         .set('host', siteHostName)
         .expect('Content-Type', /application\/json/)
         .expect(200)

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,9 +36,13 @@ export = class OutputDcatUs11 {
       const siteModel = await fetchSite(req.hostname, this.getRequestOptions(portalUrl));
 
       // Use dcatConfig query param if provided, else default to site's config
-      const dcatConfig = typeof req.query.dcatConfig === 'object'
-        ? req.query.dcatConfig
-        : _.get(siteModel, 'data.feeds.dcatUS11');
+      let dcatConfig = typeof req.query.dcatConfig === 'string'
+        ? this.parseProvidedDcatConfig(req.query.dcatConfig as string)
+        : req.query.dcatConfig;
+
+      if (!dcatConfig) {
+        dcatConfig = _.get(siteModel, 'data.feeds.dcatUS11');
+      }
 
       const { stream: dcatStream, dependencies } = getDataStreamDcatUs11(siteModel.item, dcatConfig);
       const apiTerms = getApiTermsFromDependencies(dependencies);
@@ -67,6 +71,14 @@ export = class OutputDcatUs11 {
       portal: getPortalApiUrl(portalUrl),
       authentication: null,
     };
+  }
+
+  private parseProvidedDcatConfig(dcatConfig: string) {
+    try {
+      return JSON.parse(dcatConfig);
+    } catch (err) {
+      return undefined;
+    }
   }
 
   private getCatalogSearchRequest(


### PR DESCRIPTION
[2527](https://devtopia.esri.com/dc/hub/issues/2527) - When the dcatConfig query parameter is specified, it is improperly parsed, resulting in the site dcatConfig always being used. This fixes that.