### PR TITLE
B/2539 revert www strip

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@koopjs/koop-output-dcat-us-11",
   "version": "1.3.0",
   "description": "A Koop output plugin for the DCAT-US 1.1 specification",
-  "main": "build/src/index.js",
+  "main": "src/index.js",
   "engines": {
     "node": ">= 12.0 <15"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@koopjs/koop-output-dcat-us-11",
   "version": "1.3.0",
   "description": "A Koop output plugin for the DCAT-US 1.1 specification",
-  "main": "src/index.js",
+  "main": "build/src/index.js",
   "engines": {
     "node": ">= 12.0 <15"
   },

--- a/src/dcat-us/dataset-formatter.ts
+++ b/src/dcat-us/dataset-formatter.ts
@@ -11,7 +11,9 @@ type HubDatasetAttributes = Record<string, any>;
 export type DcatDatasetTemplate = Record<string, any>;
 
 export function formatDcatDataset (hubDataset: HubDatasetAttributes, siteUrl: string, datasetTemplate: DcatDatasetTemplate) {
-  const landingPage = `${siteUrl}/datasets/${hubDataset.id}`;
+  const landingPage = siteUrl.startsWith('https://')
+    ? `${siteUrl}/datasets/${hubDataset.id}`
+    : `https://${siteUrl}/datasets/${hubDataset.id}`;
 
   const { 
     structuredLicense: { url = null } = {},

--- a/src/dcat-us/index.test.ts
+++ b/src/dcat-us/index.test.ts
@@ -2,15 +2,12 @@ import { readableFromArray, streamToString } from '../test-helpers/stream-utils'
 import { getDataStreamDcatUs11 } from './';
 
 import * as datasetFromApi from '../test-helpers/mock-dataset.json';
-import * as mockSiteModel from '../test-helpers/mock-site-model.json';
-
 import { DcatDatasetTemplate } from './dataset-formatter';
-import { IItem } from '@esri/arcgis-rest-types';
 
 const hostname = 'css-monster-qa-pre-hub.hubqa.arcgis.com';
 
 async function generateDcatFeed(
-  _siteItem: IItem,
+  hostname: string,
   datasets: any[],
   dcatCustomizations?: DcatDatasetTemplate
 ) {
@@ -25,7 +22,7 @@ async function generateDcatFeed(
 
 describe('generating DCAT-US 1.1 feed', () => {
   it('formats catalog correctly', async function () {
-    const { feed } = await generateDcatFeed(mockSiteModel.item, []);
+    const { feed } = await generateDcatFeed(hostname, []);
 
     expect(feed['@context']).toBe('https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld');
     expect(feed['@type']).toBe('dcat:Catalog');
@@ -36,7 +33,7 @@ describe('generating DCAT-US 1.1 feed', () => {
   });
 
   it('populates dataset array', async function () {
-    const { feed } = await generateDcatFeed(mockSiteModel.item, [
+    const { feed } = await generateDcatFeed(hostname, [
       datasetFromApi,
     ]);
 
@@ -63,7 +60,7 @@ describe('generating DCAT-US 1.1 feed', () => {
 
   it('respects dcat customizations of overwritable attributes', async function () {
     const { feed } = await generateDcatFeed(
-      mockSiteModel.item,
+      hostname,
       [datasetFromApi],
       {
         description: '{{name}}', // overwrite existing attribute
@@ -95,7 +92,7 @@ describe('generating DCAT-US 1.1 feed', () => {
 
   it('scrubs dcat customization of protected fields', async function () {
     const { feed } = await generateDcatFeed(
-      mockSiteModel.item,
+      hostname,
       [datasetFromApi],
       {
         '@type': '{{name}}',
@@ -134,7 +131,7 @@ describe('generating DCAT-US 1.1 feed', () => {
 
   it('reports default dependencies when no customizations', async () => {
     const { dependencies } = await generateDcatFeed(
-      mockSiteModel.item,
+      hostname,
       [datasetFromApi]
     );
 
@@ -163,7 +160,7 @@ describe('generating DCAT-US 1.1 feed', () => {
 
   it('reports custom dependencies when customizations provided', async () => {
     const { dependencies } = await generateDcatFeed(
-      mockSiteModel.item,
+      hostname,
       [datasetFromApi],
       {
         // overwrite some defaults

--- a/src/dcat-us/index.test.ts
+++ b/src/dcat-us/index.test.ts
@@ -7,12 +7,14 @@ import * as mockSiteModel from '../test-helpers/mock-site-model.json';
 import { DcatDatasetTemplate } from './dataset-formatter';
 import { IItem } from '@esri/arcgis-rest-types';
 
+const hostname = 'css-monster-qa-pre-hub.hubqa.arcgis.com';
+
 async function generateDcatFeed(
-  siteItem: IItem,
+  _siteItem: IItem,
   datasets: any[],
   dcatCustomizations?: DcatDatasetTemplate
 ) {
-  const { stream: dcatStream, dependencies } = getDataStreamDcatUs11(siteItem, dcatCustomizations);
+  const { stream: dcatStream, dependencies } = getDataStreamDcatUs11(hostname, dcatCustomizations);
 
   const docStream = readableFromArray(datasets); // no datasets since we're just checking the catalog
 
@@ -20,7 +22,6 @@ async function generateDcatFeed(
 
   return { feed: JSON.parse(feedString), dependencies };
 }
-
 
 describe('generating DCAT-US 1.1 feed', () => {
   it('formats catalog correctly', async function () {
@@ -42,9 +43,9 @@ describe('generating DCAT-US 1.1 feed', () => {
     const chk1 = feed['dataset'][0];
 
     expect(chk1['@type']).toBe('dcat:Dataset');
-    expect(chk1.identifier).toBe('https://download-test-qa-pre-a-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
+    expect(chk1.identifier).toBe('https://css-monster-qa-pre-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
     expect(chk1.license).toBe('');
-    expect(chk1.landingPage).toBe('https://download-test-qa-pre-a-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
+    expect(chk1.landingPage).toBe('https://css-monster-qa-pre-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
     expect(chk1.title).toBe('Tahoe places of interest');
     expect(chk1.description).toBe('Description. Here be Tahoe things. You can do a lot here. Here are some more words. And a few more.<div><br /></div><div>with more words</div><div><br /></div><div>adding a few more to test how long it takes for our jobs to execute.</div><div><br /></div><div>Tom was here!</div>');
     expect(chk1.keyword).toEqual([ 'Data collection', 'just modified' ]);
@@ -73,9 +74,9 @@ describe('generating DCAT-US 1.1 feed', () => {
     const chk1 = feed['dataset'][0];
 
     expect(chk1['@type']).toBe('dcat:Dataset');
-    expect(chk1.identifier).toBe('https://download-test-qa-pre-a-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
+    expect(chk1.identifier).toBe('https://css-monster-qa-pre-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
     expect(chk1.license).toBe('');
-    expect(chk1.landingPage).toBe('https://download-test-qa-pre-a-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
+    expect(chk1.landingPage).toBe('https://css-monster-qa-pre-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
     expect(chk1.title).toBe('Tahoe places of interest');
     expect(chk1.description).toBe('Tahoe places of interest');
     expect(chk1.customField).toBe('Tahoe places of interest');
@@ -112,10 +113,10 @@ describe('generating DCAT-US 1.1 feed', () => {
     const chk1 = feed['dataset'][0];
 
     expect(chk1['@type']).toBe('dcat:Dataset');
-    expect(chk1.identifier).toBe('https://download-test-qa-pre-a-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
+    expect(chk1.identifier).toBe('https://css-monster-qa-pre-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
     expect(chk1.license).toBe('');
     expect(chk1.webService).toBe(undefined);
-    expect(chk1.landingPage).toBe('https://download-test-qa-pre-a-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
+    expect(chk1.landingPage).toBe('https://css-monster-qa-pre-hub.hubqa.arcgis.com/datasets/f4bcc1035b7d46cba95e977f4affb6be_0');
     expect(chk1.title).toBe('Tahoe places of interest');
     expect(chk1.description).toBe('Description. Here be Tahoe things. You can do a lot here. Here are some more words. And a few more.<div><br /></div><div>with more words</div><div><br /></div><div>adding a few more to test how long it takes for our jobs to execute.</div><div><br /></div><div>Tom was here!</div>');
     expect(chk1.keyword).toEqual([ 'Data collection', 'just modified' ]);

--- a/src/dcat-us/index.ts
+++ b/src/dcat-us/index.ts
@@ -1,10 +1,9 @@
-import { IItem } from '@esri/arcgis-rest-portal';
 import { listDependencies } from 'adlib';
 import { buildDatasetTemplate, DcatDatasetTemplate, formatDcatDataset } from './dataset-formatter';
 import { FeedFormatterStream } from './feed-formatter-stream';
 import { DISTRIBUTION_DEPENDENCIES } from './_generate-distributions';
 
-export function getDataStreamDcatUs11(siteItem: IItem, dcatCustomizations?: DcatDatasetTemplate) {
+export function getDataStreamDcatUs11(hostname: string, dcatCustomizations?: DcatDatasetTemplate) {
   const catalogStr = JSON.stringify({
       '@context':
         'https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld',
@@ -23,7 +22,7 @@ export function getDataStreamDcatUs11(siteItem: IItem, dcatCustomizations?: Dcat
   const datasetTemplate = buildDatasetTemplate(dcatCustomizations);
 
   const formatFn = (chunk) => {
-    return formatDcatDataset(chunk, siteItem.url, datasetTemplate);
+    return formatDcatDataset(chunk, hostname, datasetTemplate);
   };
 
   return {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -193,7 +193,7 @@ describe('Output Plugin', () => {
         .expect('Content-Type', /application\/json/)
         .expect(200)
         .expect(() => {
-          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(customConfigSiteModel.item, customConfigSiteModel.data.feeds.dcatUS11);
+          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(siteHostName, customConfigSiteModel.data.feeds.dcatUS11);
         });
     });
 
@@ -208,7 +208,7 @@ describe('Output Plugin', () => {
         .expect('Content-Type', /application\/json/)
         .expect(200)
         .expect(() => {
-          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(mockSiteModel.item, dcatConfig);
+          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(siteHostName, dcatConfig);
         });
     });
 
@@ -224,7 +224,7 @@ describe('Output Plugin', () => {
         .expect('Content-Type', /application\/json/)
         .expect(200)
         .expect(() => {
-          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(mockSiteModel.item, dcatConfig);
+          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(siteHostName, dcatConfig);
         });
     });
 
@@ -254,7 +254,7 @@ describe('Output Plugin', () => {
         .expect('Content-Type', /application\/json/)
         .expect(200)
         .expect(() => {
-          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(customConfigSiteModel.item, customConfigSiteModel.data.feeds.dcatUS11);
+          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(siteHostName, customConfigSiteModel.data.feeds.dcatUS11);
         });
     });
 
@@ -276,6 +276,36 @@ describe('Output Plugin', () => {
           };
           const actualSearchRequest = _.get(plugin.model.pullStream, 'mock.calls[0][0].res.locals.searchRequest')
           expect(actualSearchRequest).toStrictEqual(expectedSearchRequest);
+        });
+    });
+
+    it('Uses the siteHostName instead of the dataset id', async () => {
+      // Change fetchSite's return value to include a custom dcat config
+      const customConfigSiteModel: IModel = _.cloneDeep(mockSiteModel);
+      customConfigSiteModel.data.feeds = {
+        dcatUS11: {
+          "title": "{{default.name}}",
+          "description": "{{default.description}}",
+          "keyword": "{{item.tags}}",
+          "issued": "{{item.created:toISO}}",
+          "modified": "{{item.modified:toISO}}",
+          "publisher": { "name": "{{default.source.source}}" },
+          "contactPoint": {
+            "fn": "{{item.owner}}",
+            "hasEmail": "{{org.portalProperties.links.contactUs.url}}"
+          },
+          "landingPage": "some silly standard",
+        }
+      }
+      mockFetchSite.mockResolvedValue(customConfigSiteModel);
+
+      await request(app)
+        .get('/dcat')
+        .set('host', 'css-monster-qa-pre-hub.hubqa.arcgis.com')
+        .expect('Content-Type', /application\/json/)
+        .expect(200)
+        .expect(() => {
+          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith('css-monster-qa-pre-hub.hubqa.arcgis.com', customConfigSiteModel.data.feeds.dcatUS11);
         });
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export = class OutputDcatUs11 {
     res.set('Content-Type', 'application/json');
 
     try {
-      const siteModel = await fetchSite(req.hostname, this.getRequestOptions(portalUrl));
+      const siteModel = await fetchSite('www.spatial-data.brisbane.qld.gov.au', this.getRequestOptions(portalUrl));
 
       // Use dcatConfig query param if provided, else default to site's config
       let dcatConfig = typeof req.query.dcatConfig === 'string'
@@ -44,7 +44,8 @@ export = class OutputDcatUs11 {
         dcatConfig = _.get(siteModel, 'data.feeds.dcatUS11');
       }
 
-      const { stream: dcatStream, dependencies } = getDataStreamDcatUs11(siteModel.item, dcatConfig);
+      const { stream: dcatStream, dependencies } = getDataStreamDcatUs11(req.hostname, dcatConfig);
+
       const apiTerms = getApiTermsFromDependencies(dependencies);
 
       // Request a single dataset if id is provided, else default to site's catalog

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export = class OutputDcatUs11 {
     res.set('Content-Type', 'application/json');
 
     try {
-      const siteModel = await fetchSite('www.spatial-data.brisbane.qld.gov.au', this.getRequestOptions(portalUrl));
+      const siteModel = await fetchSite(req.hostname, this.getRequestOptions(portalUrl));
 
       // Use dcatConfig query param if provided, else default to site's config
       let dcatConfig = typeof req.query.dcatConfig === 'string'

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,8 @@ export = class OutputDcatUs11 {
     res.set('Content-Type', 'application/json');
 
     try {
-      const siteModel = await fetchSite(req.hostname, this.getRequestOptions(portalUrl));
+      const hostname = req.hostname;
+      const siteModel = await fetchSite(hostname, this.getRequestOptions(portalUrl));
 
       // Use dcatConfig query param if provided, else default to site's config
       let dcatConfig = typeof req.query.dcatConfig === 'string'
@@ -44,7 +45,7 @@ export = class OutputDcatUs11 {
         dcatConfig = _.get(siteModel, 'data.feeds.dcatUS11');
       }
 
-      const { stream: dcatStream, dependencies } = getDataStreamDcatUs11(req.hostname, dcatConfig);
+      const { stream: dcatStream, dependencies } = getDataStreamDcatUs11(hostname, dcatConfig);
 
       const apiTerms = getApiTermsFromDependencies(dependencies);
 


### PR DESCRIPTION
[2539](https://devtopia.esri.com/dc/hub/issues/2539) - Currently, the feed obtains the landing and identifier urls from the url of the dataset's underlying item in ArcGIS. It's not currently clear why (at least to me), but this url **is not** always the correct one to use. In the linked issue, the item url corresponds to the `opendata` subdomain for the site, not the custom domain. This PR fixes this so that logic is consistent with the original DCAT endpoint: the url is taken from the request hostname.