### PR TITLE
Scrub attempts to overwrite 'distribution' rather than 'distributions'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 Fixed
-- Scrub attempts to overwrite `distribution` rather than `distributions` [#15](https://github.com/koopjs/koop-output-dcat-us-11/pull/15)}
+- Scrub attempts to overwrite `distribution` rather than `distributions` [#15](https://github.com/koopjs/koop-output-dcat-us-11/pull/15)
 
 ## 1.4.1
 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG.md
 
+## Unreleased
+
+Fixed
+- Scrub attempts to overwrite `distribution` rather than `distributions` [#15](https://github.com/koopjs/koop-output-dcat-us-11/pull/15)}
+
 ## 1.4.1
 Fixed
 - Add proper error status [#14](https://github.com/koopjs/koop-output-dcat-us-11/pull/14)

--- a/src/dcat-us/dataset-formatter.ts
+++ b/src/dcat-us/dataset-formatter.ts
@@ -84,7 +84,7 @@ function scrubProtectedKeys (customizations: DcatDatasetTemplate): DcatDatasetTe
     if (scrubbedCustomizations.contactPoint) {
       delete scrubbedCustomizations.contactPoint['@type'];
     }
-    delete scrubbedCustomizations.distributions;
+    delete scrubbedCustomizations.distribution;
   }
 
   return scrubbedCustomizations;

--- a/src/dcat-us/index.test.ts
+++ b/src/dcat-us/index.test.ts
@@ -102,7 +102,7 @@ describe('generating DCAT-US 1.1 feed', () => {
         identifier: '{{name}}',
         landingPage: '{{name}}',
         webService: '{{name}}',
-        distributions: '{{name}}',
+        distribution: '{{name}}',
         contactPoint: {
           '@type': '{{name}}',
           fn: '{{owner}}',


### PR DESCRIPTION
Discovered as part of https://devtopia.esri.com/dc/hub/issues/2649
