### PR TITLE
B/2880 fallback bug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ const portalUrl = config.has('arcgisPortal')
   * @returns - a list of valid Hub API fields
 */
 async function getApiTermsFromDependencies (dependencies: string[]) {
+  if (!dependencies || !Array.isArray(dependencies)) return undefined;
+
   // Only get valid Hub API fields if they are needed
   const doesPathHierarchyExist = dependencies.filter(dep => dep.includes('||')).length;
   const validApiFields: string[] = doesPathHierarchyExist ? await hubApiRequest('fields') : [];


### PR DESCRIPTION
[2880](https://devtopia.esri.com/dc/hub/issues/2880) - It appears that during the migration, handling of fallback logic (path hierarchies in adlib terms) was not implemented when converting adlib dependency specifications to API fields. This re-introduces it. Note that the adlib spec allows for the last field of a path hierarchy to be _either_ a valid Hub API field _or_ a literal (see [here](https://github.com/Esri/adlib) under `Path Hierarchies with Defaults`) but there is no syntax to differentiate them. This implementation makes a request for valid fields, such that if the last field is a valid API field, it is used in the search request. Otherwise, it is not.