### PR TITLE
F/3978 customizable spatial attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@koopjs/koop-output-dcat-us-11",
   "version": "1.9.1",
   "description": "A Koop output plugin for the DCAT-US 1.1 specification",
-  "main": "build/src/index.js",
+  "main": "src/index.js",
   "engines": {
     "node": ">= 12.0 <15"
   },
@@ -71,7 +71,6 @@
     "@esri/arcgis-rest-feature-layer": "^3.2.1"
   },
   "volta": {
-    "node": "14.16.1",
-    "yarn": "1.22.19"
+    "node": "14.16.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@koopjs/koop-output-dcat-us-11",
   "version": "1.9.1",
   "description": "A Koop output plugin for the DCAT-US 1.1 specification",
-  "main": "src/index.js",
+  "main": "build/src/index.js",
   "engines": {
     "node": ">= 12.0 <15"
   },
@@ -71,6 +71,7 @@
     "@esri/arcgis-rest-feature-layer": "^3.2.1"
   },
   "volta": {
-    "node": "14.16.1"
+    "node": "14.16.1",
+    "yarn": "1.22.19"
   }
 }

--- a/src/dcat-us/dataset-formatter.test.ts
+++ b/src/dcat-us/dataset-formatter.test.ts
@@ -37,7 +37,7 @@ it('dcatHelper: it does not throw an error if there are no customizations', () =
 });
 
 it('dcatHelper: it does not throw an error customizations are null', () => {
-  const customizations = null;
+  const customizations = undefined;
   const template = buildDatasetTemplate(customizations);
   expect(template).toBeTruthy();
 });

--- a/src/dcat-us/dataset-formatter.ts
+++ b/src/dcat-us/dataset-formatter.ts
@@ -3,7 +3,7 @@ import { adlib, TransformsList } from 'adlib';
 import { isPage } from '@esri/hub-sites';
 import { baseDatasetTemplate } from './base-dataset-template';
 import { _generateDistributions } from './_generate-distributions';
-import { cloneObject, DatasetResource, datasetToContent, getContentSiteUrls, IModel } from '@esri/hub-common';
+import { cloneObject, DatasetResource, datasetToContent, getContentSiteUrls, IModel, isBBox } from '@esri/hub-common';
 import { IItem } from '@esri/arcgis-rest-portal';
 import { nonEditableFieldPaths } from './noneditable-fields';
 
@@ -66,14 +66,17 @@ export function formatDcatDataset (hubDataset: HubDatasetAttributes, siteUrl: st
     downloadLink
   });
 
-  if (_.has(hubDataset, 'extent.coordinates')) {
-    dcatDataset.spatial = hubDataset.extent.coordinates.join(',');
+  const spatial = computeSpatialProperty(datasetTemplate, dcatDataset);
+  if (spatial) {
+    dcatDataset.spatial = spatial;
 
     // https://project-open-data.cio.gov/v1.1/schema/#theme
     // allow theme to be overridden
     if (_.isEmpty(datasetTemplate.theme)) {
       dcatDataset.theme = ['geospatial'];
     }
+  } else if (dcatDataset.spatial) {
+    delete dcatDataset.spatial;
   }
 
   return indent(JSON.stringify(dcatDataset, null, '\t'), 2);
@@ -116,4 +119,36 @@ function resetUninterpolatedPaths(dataset, fieldPaths) {
       _.set(dataset, path, '');
     }
   });
+}
+
+/**
+ * Determines what to put in the spatial property based on template, raw dataset, and adlib-ed dataset
+ */
+function computeSpatialProperty(datasetTemplate, dcatDataset) {
+  // Either the template does not have spatial key set or somehow adlib does not inject, so don't set
+  if (!datasetTemplate.spatial || !dcatDataset.spatial) return undefined;
+
+  // Adlib returns the input for a templated value when it cannot resolve a non-falsey value
+  if (datasetTemplate.spatial === dcatDataset.spatial) return undefined;
+
+  // Get coordinates from valid GeoJSON bbox envelope or raw coordinates
+  let coordinates;
+  if (dcatDataset.spatial.type === 'envelope' && Array.isArray(dcatDataset.spatial.coordinates)) {
+    coordinates = dcatDataset.spatial.coordinates;
+  } else if (Array.isArray(dcatDataset.spatial)) {
+    coordinates = dcatDataset.spatial;
+  }
+
+  // Just return what adlib returned if coordinates cannot be obtained
+  if (!coordinates) return dcatDataset.spatial;
+
+  // If valid bbox coordinates return stringified
+  if (!isBBox(coordinates)) return undefined;
+  if (coordinates.length != 2 || coordinates[0].length != 2 || coordinates[1].length != 2) {
+    return undefined;
+  }
+  if (!_.isNumber(coordinates[0][0]) || !_.isNumber(coordinates[0][1]) || !_.isNumber(coordinates[1][0]) || !_.isNumber(coordinates[1][1])) {
+    return undefined;
+  }
+  return `${coordinates[0][0].toFixed(4)},${coordinates[0][1].toFixed(4)},${coordinates[1][0].toFixed(4)},${coordinates[1][1].toFixed(4)}`;
 }

--- a/src/dcat-us/dataset-formatter.ts
+++ b/src/dcat-us/dataset-formatter.ts
@@ -129,7 +129,7 @@ function computeSpatialProperty(datasetTemplate, dcatDataset) {
   if (!datasetTemplate.spatial || !dcatDataset.spatial) return undefined;
 
   // Adlib returns the input for a templated value when it cannot resolve a non-falsey value
-  if (datasetTemplate.spatial === dcatDataset.spatial) return undefined;
+  if (typeof dcatDataset.spatial === 'string' && dcatDataset.spatial.match(/{{.+}}/)?.length) return undefined;
 
   // Get coordinates from valid GeoJSON bbox envelope or raw coordinates
   let coordinates;

--- a/src/dcat-us/index.test.ts
+++ b/src/dcat-us/index.test.ts
@@ -54,7 +54,7 @@ describe('generating DCAT-US 1.1 feed', () => {
     expect(chk1.publisher).toEqual({ name: 'QA Premium Alpha Hub' });
     expect(chk1.contactPoint).toEqual({ '@type': 'vcard:Contact', fn: 'thervey_qa_pre_a_hub' });
     expect(chk1.accessLevel).toBe('public');
-    expect(chk1.spatial).toBe('-121.118,38.7754,-119.009,39.359');
+    expect(chk1.spatial).toBe('-121.1180,38.7754,-119.0090,39.3590');
     expect(chk1.theme).toEqual(['geospatial']);
 
     expect(chk1.distribution).toBeInstanceOf(Array);
@@ -86,7 +86,7 @@ describe('generating DCAT-US 1.1 feed', () => {
     expect(chk1.publisher).toEqual({ name: 'QA Premium Alpha Hub' });
     expect(chk1.contactPoint).toEqual({ '@type': 'vcard:Contact', fn: 'thervey_qa_pre_a_hub' });
     expect(chk1.accessLevel).toBe('public');
-    expect(chk1.spatial).toBe('-121.118,38.7754,-119.009,39.359');
+    expect(chk1.spatial).toBe('-121.1180,38.7754,-119.0090,39.3590');
     expect(chk1.theme).toEqual(['geospatial']);
 
     expect(chk1.distribution).toBeInstanceOf(Array);
@@ -128,7 +128,7 @@ describe('generating DCAT-US 1.1 feed', () => {
       fn: 'thervey_qa_pre_a_hub' 
     });
     expect(chk1.accessLevel).toBe('public');
-    expect(chk1.spatial).toBe('-121.118,38.7754,-119.009,39.359');
+    expect(chk1.spatial).toBe('-121.1180,38.7754,-119.0090,39.3590');
     expect(chk1.theme).toEqual(['geospatial']);
 
     expect(chk1.distribution).toBeInstanceOf(Array);

--- a/src/dcat-us/noneditable-fields.ts
+++ b/src/dcat-us/noneditable-fields.ts
@@ -4,6 +4,5 @@ export const nonEditableFieldPaths = [
   'identifier',
   'landingPage',
   'webService',
-  'spatial',
   'contactPoint[@type]',
 ];

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -98,7 +98,7 @@ describe('Output Plugin', () => {
 
     const expressRequest: express.Request =
       plugin.model.pullStream.mock.calls[0][0];
-    expect(expressRequest.res.locals.searchRequest).toEqual({
+    expect(expressRequest.res?.locals.searchRequest).toEqual({
       filter: {
         group: [
           '3b9ffb00851f47dab74494018ffa00fb',
@@ -135,15 +135,15 @@ describe('Output Plugin', () => {
 
     const expressRequest: express.Request =
       localPlugin.model.pullStream.mock.calls[0][0];
-    expect(expressRequest.res.locals.searchRequest.options.portal).toBe(
+    expect(expressRequest.res?.locals.searchRequest.options.portal).toBe(
       qaPortal,
     );
   });
 
   it('Properly converts adlib path hierarchies to Hub API Fields', async () => {
     // Change fetchSite's return value to include a custom dcat config
-    const customConfigSiteModel: IModel = _.cloneDeep(mockSiteModel);
-    customConfigSiteModel.data.feeds = {
+    const customConfigSiteModel: IModel = _.cloneDeep(mockSiteModel) as any;
+    (customConfigSiteModel.data || {}).feeds = {
       dcatUS11: {
         "title": "{{name}}",
         "description": "{{description}}",
@@ -301,8 +301,8 @@ describe('Output Plugin', () => {
 
     it('Properly passes a site\'s custom dcat configurations to getDataStreamDcatUs11 when no dcatConfig is provided', async () => {
       // Change fetchSite's return value to include a custom dcat config
-      const customConfigSiteModel: IModel = _.cloneDeep(mockSiteModel);
-      customConfigSiteModel.data.feeds = {
+      const customConfigSiteModel: IModel = _.cloneDeep(mockSiteModel) as any;
+      (customConfigSiteModel.data || {}).feeds = {
         dcatUS11: {
           "title": "{{name}}",
           "description": "{{description}}",
@@ -326,7 +326,7 @@ describe('Output Plugin', () => {
         .expect('Content-Type', /application\/json/)
         .expect(200)
         .expect(() => {
-          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(siteHostName, customConfigSiteModel, customConfigSiteModel.data.feeds.dcatUS11);
+          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith(siteHostName, customConfigSiteModel, customConfigSiteModel.data?.feeds.dcatUS11);
         });
     });
 
@@ -414,8 +414,8 @@ describe('Output Plugin', () => {
 
     it('Uses the siteHostName instead of the dataset id', async () => {
       // Change fetchSite's return value to include a custom dcat config
-      const customConfigSiteModel: IModel = _.cloneDeep(mockSiteModel);
-      customConfigSiteModel.data.feeds = {
+      const customConfigSiteModel: IModel = _.cloneDeep(mockSiteModel) as any;
+      (customConfigSiteModel.data || {}).feeds = {
         dcatUS11: {
           "title": "{{default.name}}",
           "description": "{{default.description}}",
@@ -438,7 +438,7 @@ describe('Output Plugin', () => {
         .expect('Content-Type', /application\/json/)
         .expect(200)
         .expect(() => {
-          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith('css-monster-qa-pre-hub.hubqa.arcgis.com', customConfigSiteModel, customConfigSiteModel.data.feeds.dcatUS11);
+          expect(mockGetDataStreamDcatUs11).toHaveBeenCalledWith('css-monster-qa-pre-hub.hubqa.arcgis.com', customConfigSiteModel, customConfigSiteModel.data?.feeds.dcatUS11);
         });
     });
   });


### PR DESCRIPTION
This PR:
- Introduces the ability to edit the spatial field, and properly process/inject it as a string from either `extent` or `itemExtent` fields. The returned string is always 4 numbers fixed to 4 decimals each
- Fixes a few typescript compiler warnings associated with strict-null-checks in tests
- Adds some tests