### PR TITLE
handle stream error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export = class OutputDcatUs11 {
       const datasetStream = await this.getDatasetStream(req);
       datasetStream.on('error', (err) => {
         if (req.next) {
-          req.next(err)
+          req.next(err);
         }
       }).pipe(dcatStream).pipe(res);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,11 @@ export = class OutputDcatUs11 {
       const { stream: dcatStream } = getDataStreamDcatUs11(feedTemplate, feedTemplateTransforms);
 
       const datasetStream = await this.getDatasetStream(req);
-      datasetStream
-        .pipe(dcatStream)
-        .pipe(res);
+      datasetStream.on('error', (err) => {
+        if (req.next) {
+          req.next(err)
+        }
+      }).pipe(dcatStream).pipe(res);
 
     } catch (err) {
       res.status(err.statusCode).send(this.getErrorResponse(err));


### PR DESCRIPTION
This PR passes downstream error from koop providers to koop server instance which would handle the error.

https://devtopia.esri.com/dc/hub/issues/10625